### PR TITLE
Use bucket name in generated N1QL query

### DIFF
--- a/src/EFCore.Couchbase/Query/Expressions/Internal/DocumentQueryExpression.cs
+++ b/src/EFCore.Couchbase/Query/Expressions/Internal/DocumentQueryExpression.cs
@@ -44,7 +44,9 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Expressions.Internal
             SelectExpression selectExpression)
             => ((CouchbaseQueryContext)queryContext).CouchbaseClient.ExecuteSqlQuery(
                 collectionId,
-                selectExpression.ToSqlQuery(queryContext.ParameterValues));
+                selectExpression.ToSqlQuery(
+                    ((CouchbaseQueryContext)queryContext).CouchbaseClient.BucketName,
+                    queryContext.ParameterValues));
 
         private static readonly MethodInfo _queryAsyncMethodInfo
             = typeof(DocumentQueryExpression).GetTypeInfo().GetDeclaredMethod(nameof(_QueryAsync));
@@ -56,7 +58,9 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Expressions.Internal
             SelectExpression selectExpression)
             => ((CouchbaseQueryContext)queryContext).CouchbaseClient.ExecuteSqlQueryAsync(
                 collectionId,
-                selectExpression.ToSqlQuery(queryContext.ParameterValues));
+                selectExpression.ToSqlQuery(
+                    ((CouchbaseQueryContext)queryContext).CouchbaseClient.BucketName,
+                    queryContext.ParameterValues));
 
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
 

--- a/src/EFCore.Couchbase/Query/Expressions/Internal/SelectExpression.cs
+++ b/src/EFCore.Couchbase/Query/Expressions/Internal/SelectExpression.cs
@@ -122,10 +122,10 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Expressions.Internal
             [NotNull] Expression arguments)
             => _querySqlGeneratorFactory.CreateFromSql(this, sql, arguments);
 
-        public CouchbaseSqlQuery ToSqlQuery(IReadOnlyDictionary<string, object> parameterValues)
-            => CreateDefaultQuerySqlGenerator().GenerateSqlQuery(parameterValues);
+        public CouchbaseSqlQuery ToSqlQuery(string bucketName, IReadOnlyDictionary<string, object> parameterValues)
+            => CreateDefaultQuerySqlGenerator().GenerateSqlQuery(bucketName, parameterValues);
 
         public override string ToString()
-            => ToSqlQuery(new Dictionary<string, object>()).Query;
+            => ToSqlQuery("bucket", new Dictionary<string, object>()).Query;
     }
 }

--- a/src/EFCore.Couchbase/Query/Sql/ISqlGenerator.cs
+++ b/src/EFCore.Couchbase/Query/Sql/ISqlGenerator.cs
@@ -10,12 +10,15 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Sql
     public interface ISqlGenerator
     {
         /// <summary>
-        ///     Generates a SQL query for the given parameter values.
+        ///     Generates a SQL query for the given bucket name and parameter values.
         /// </summary>
+        /// <param name="bucketName">The bucket name.</param>
         /// <param name="parameterValues"> The parameter values. </param>
         /// <returns>
         ///     The SQL query.
         /// </returns>
-        CouchbaseSqlQuery GenerateSqlQuery([NotNull] IReadOnlyDictionary<string, object> parameterValues);
+        CouchbaseSqlQuery GenerateSqlQuery(
+            [NotNull] string bucketName,
+            [NotNull] IReadOnlyDictionary<string, object> parameterValues);
     }
 }

--- a/src/EFCore.Couchbase/Query/Sql/Internal/CouchbaseSqlGenerator.cs
+++ b/src/EFCore.Couchbase/Query/Sql/Internal/CouchbaseSqlGenerator.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -26,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Sql.Internal
         private CoreTypeMapping _typeMapping;
 
         private readonly StringBuilder _sqlBuilder = new StringBuilder();
+        private string _bucketName;
         private IReadOnlyDictionary<string, object> _parameterValues;
         private List<SqlParameter> _sqlParameters;
 
@@ -73,9 +75,14 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Sql.Internal
         }
 
         public CouchbaseSqlQuery GenerateSqlQuery(
+            string bucketName,
             IReadOnlyDictionary<string, object> parameterValues)
         {
+            Check.NotNull(bucketName, nameof(bucketName));
+            Check.NotNull(parameterValues, nameof(parameterValues));
+
             _sqlBuilder.Clear();
+            _bucketName = bucketName;
             _parameterValues = parameterValues;
             _sqlParameters = new List<SqlParameter>();
 
@@ -210,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Sql.Internal
                     Visit(selectExpression.Projection);
                     _sqlBuilder.AppendLine();
 
-                    _sqlBuilder.Append("FROM root ");
+                    _sqlBuilder.AppendFormat("FROM {0} ", _bucketName);
                     Visit(selectExpression.FromExpression);
                     _sqlBuilder.AppendLine();
 

--- a/src/EFCore.Couchbase/Storage/Internal/CouchbaseClientWrapper.cs
+++ b/src/EFCore.Couchbase/Storage/Internal/CouchbaseClientWrapper.cs
@@ -35,9 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
         public static readonly JsonSerializer Serializer = new JsonSerializer();
         private ClientConfiguration _clientConfiguration;
         private IAuthenticator _authenticator;
-        private string _bucketName;
         private IBucket _bucket;
         private Cluster _cluster;
+
+        public string BucketName { get; }
 
         static CouchbaseClientWrapper()
         {
@@ -54,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
 
             _clientConfiguration = options.ClientConfiguration;
             _authenticator = options.Authenticator;
-            _bucketName = options.BucketName;
+            BucketName = options.BucketName;
 
             _executionStrategyFactory = executionStrategyFactory;
             _commandLogger = commandLogger;
@@ -77,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
 
         private IBucket ConnectToCouchbaseBucket()
         {
-            return Cluster.OpenBucket(_bucketName);
+            return Cluster.OpenBucket(BucketName);
         }
 
         public bool CreateDatabaseIfNotExists()
@@ -332,18 +333,18 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
                 private readonly CouchbaseClientWrapper _CouchbaseClient;
                 private readonly string _containerId;
                 private readonly CouchbaseSqlQuery _CouchbaseSqlQuery;
-        
+
                 public Enumerator(DocumentEnumerable documentEnumerable)
                 {
                     _CouchbaseClient = documentEnumerable._CouchbaseClient;
                     _containerId = documentEnumerable._containerId;
                     _CouchbaseSqlQuery = documentEnumerable._CouchbaseSqlQuery;
                 }
-        
+
                 public JObject Current { get; private set; }
-        
+
                 object IEnumerator.Current => Current;
-        
+
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool MoveNext()
                 {
@@ -355,17 +356,17 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
                         {
                             _query = _CouchbaseClient.CreateQuery(_containerId, _CouchbaseSqlQuery);
                         }
-        
+
                         if (!_query.HasMoreResults)
                         {
                             Current = default;
                             return false;
                         }
-        
+
                         _responseStream = _query.FetchNextSetAsync().GetAwaiter().GetResult().Content;
                         _reader = new StreamReader(_responseStream);
                         _jsonReader = new JsonTextReader(_reader);
-        
+
                         while (_jsonReader.Read())
                         {
                             if (_jsonReader.TokenType == JsonToken.StartObject)
@@ -379,11 +380,11 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
                                 }
                             }
                         }
-        
+
                         ObjectFound:
                         ;
                     }
-        
+
                     while (_jsonReader.Read())
                     {
                         if (_jsonReader.TokenType == JsonToken.StartObject)
@@ -398,18 +399,18 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
                             }
                         }
                     }
-        
+
                     _jsonReader.Close();
                     _jsonReader = null;
                     _reader.Dispose();
                     _reader = null;
                     _responseStream.Dispose();
                     _responseStream = null;
-        
+
                     return MoveNext();
                     */
                 }
-        
+
                 public void Dispose()
                 {
                     _jsonReader?.Close();
@@ -419,7 +420,7 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Storage.Internal
                     _responseStream?.Dispose();
                     _responseStream = null;
                 }
-        
+
                 public void Reset() => throw new NotImplementedException();
             }
         }


### PR DESCRIPTION
Motivation
------------
N1QL queries require the bucket name in the query text.

Modifications
---------------
Provide a mechanism for the query execution mechanism to pass the bucket name through to the ISqlGenerator so that the bucket name is included in the generated SQL.