### PR TITLE
Implement basic query support

### DIFF
--- a/src/EFCore.Couchbase/Query/Expressions/Internal/QueryShaperExpression.cs
+++ b/src/EFCore.Couchbase/Query/Expressions/Internal/QueryShaperExpression.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Expressions.Internal
         {
             foreach (var jObject in innerEnumerable)
             {
-                yield return shaper(jObject);
+                yield return shaper((JObject) jObject.GetValue("c"));
             }
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query.Expressions.Internal
                         return false;
                     }
 
-                    Current = _shaper(_enumerator.Current);
+                    Current = _shaper((JObject) _enumerator.Current?.GetValue("c"));
                     return true;
                 }
 

--- a/test/EFCore.Couchbase.FunctionalTests/Query/SimpleQueryCouchbaseTest.cs
+++ b/test/EFCore.Couchbase.FunctionalTests/Query/SimpleQueryCouchbaseTest.cs
@@ -40,9 +40,9 @@ namespace Microsoft.EntityFrameworkCore.Couchbase.Query
             await AssertQuery<Customer>(isAsync, cs => cs, entryCount: 91);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Shaper_command_caching_when_parameter_names_different()
@@ -50,13 +50,13 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Shaper_command_caching_when_parameter_names_different();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")) AND true)",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI"")) AND true)",
                 //
-                @"SELECT c
-FROM root c
-WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")) AND true)");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI"")) AND true)");
         }
 
         public override void Lifting_when_subquery_nested_order_by_anonymous()
@@ -64,9 +64,9 @@ WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""
             base.Lifting_when_subquery_nested_order_by_anonymous();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Lifting_when_subquery_nested_order_by_simple()
@@ -74,9 +74,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Lifting_when_subquery_nested_order_by_simple();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Local_dictionary(bool isAsync)
@@ -87,8 +87,8 @@ WHERE (c[""Discriminator""] = ""Order"")");
                 @"@__p_0='ALFKI'
 
 SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = @__p_0))");
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = @__p_0))");
         }
 
         public override void Method_with_constant_queryable_arg()
@@ -96,9 +96,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = @__p_0))")
             base.Method_with_constant_queryable_arg();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Entity_equality_self(bool isAsync)
@@ -106,9 +106,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Entity_equality_self(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = c[""CustomerID""]))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = c.CustomerID))");
         }
 
         public override async Task Entity_equality_local(bool isAsync)
@@ -116,9 +116,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = c[""Custom
             await base.Entity_equality_local(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Join_with_entity_equality_local_on_both_sources(bool isAsync)
@@ -126,9 +126,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Join_with_entity_equality_local_on_both_sources(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Entity_equality_local_inline(bool isAsync)
@@ -136,9 +136,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Entity_equality_local_inline(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Entity_equality_null(bool isAsync)
@@ -146,9 +146,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Entity_equality_null(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = null))");
         }
 
         public override async Task Entity_equality_not_null(bool isAsync)
@@ -156,9 +156,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
             await base.Entity_equality_not_null(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID != null))");
         }
 
         public override void Query_when_evaluatable_queryable_method_call_with_repository()
@@ -197,9 +197,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != null))");
             }
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Queryable_reprojection(bool isAsync)
@@ -207,9 +207,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Queryable_reprojection(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Default_if_empty_top_level(bool isAsync)
@@ -217,9 +217,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Default_if_empty_top_level(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Employee"") AND (c.EmployeeID = 4294967295))");
         }
 
         public override async Task Join_with_default_if_empty_on_both_sources(bool isAsync)
@@ -227,9 +227,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295
             await base.Join_with_default_if_empty_on_both_sources(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Default_if_empty_top_level_followed_by_projecting_constant(bool isAsync)
@@ -237,9 +237,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Default_if_empty_top_level_followed_by_projecting_constant(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Default_if_empty_top_level_positive(bool isAsync)
@@ -247,9 +247,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Default_if_empty_top_level_positive(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] > 0))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Employee"") AND (c.EmployeeID > 0))");
         }
 
         public override Task Default_if_empty_top_level_arg(bool isAsync)
@@ -263,9 +263,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] > 0))");
             await base.Default_if_empty_top_level_arg_followed_by_projecting_constant(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Default_if_empty_top_level_projection(bool isAsync)
@@ -273,9 +273,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Default_if_empty_top_level_projection(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Employee"") AND (c.EmployeeID = 4294967295))");
         }
 
         public override async Task Where_query_composition(bool isAsync)
@@ -283,9 +283,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295
             await base.Where_query_composition(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition_is_null(bool isAsync)
@@ -293,9 +293,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition_is_null(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition_is_not_null(bool isAsync)
@@ -303,9 +303,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition_is_null(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition_entity_equality_one_element_SingleOrDefault(bool isAsync)
@@ -313,9 +313,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition_entity_equality_one_element_SingleOrDefault(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition_entity_equality_one_element_FirstOrDefault(bool isAsync)
@@ -323,9 +323,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition_entity_equality_one_element_FirstOrDefault(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition_entity_equality_no_elements_SingleOrDefault(bool isAsync)
@@ -333,9 +333,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition_entity_equality_no_elements_SingleOrDefault(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition_entity_equality_no_elements_FirstOrDefault(bool isAsync)
@@ -343,9 +343,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition_entity_equality_no_elements_FirstOrDefault(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(bool isAsync)
@@ -353,9 +353,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition2(bool isAsync)
@@ -363,9 +363,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition2_FirstOrDefault(bool isAsync)
@@ -373,9 +373,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition2_FirstOrDefault(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition2_FirstOrDefault_with_anonymous(bool isAsync)
@@ -383,9 +383,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition2_FirstOrDefault_with_anonymous(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override void Select_Subquery_Single()
@@ -393,9 +393,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             base.Select_Subquery_Single();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""OrderDetail"")");
         }
 
         public override void Select_Where_Subquery_Deep_Single()
@@ -403,9 +403,9 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             base.Select_Where_Subquery_Deep_Single();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 10344))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""OrderDetail"") AND (c.OrderID = 10344))");
         }
 
         public override void Select_Where_Subquery_Deep_First()
@@ -413,9 +413,9 @@ WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 10344))");
             base.Select_Where_Subquery_Deep_First();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""OrderDetail"")");
         }
 
         public override void Select_Where_Subquery_Equality()
@@ -423,9 +423,9 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             base.Select_Where_Subquery_Equality();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Where_subquery_anon(bool isAsync)
@@ -433,9 +433,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Where_subquery_anon(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_subquery_anon_nested(bool isAsync)
@@ -443,9 +443,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_subquery_anon_nested(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_SelectMany(bool isAsync)
@@ -479,9 +479,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 assertOrder: true);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""VINET""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""VINET""))");
         }
 
         public override async Task Let_any_subquery_anonymous(bool isAsync)
@@ -489,9 +489,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""VINET"")
             await base.Let_any_subquery_anonymous(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_arithmetic(bool isAsync)
@@ -499,9 +499,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_arithmetic(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task OrderBy_condition_comparison(bool isAsync)
@@ -509,9 +509,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.OrderBy_condition_comparison(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Product"")");
         }
 
         public override async Task OrderBy_ternary_conditions(bool isAsync)
@@ -519,9 +519,9 @@ WHERE (c[""Discriminator""] = ""Product"")");
             await base.OrderBy_ternary_conditions(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Product"")");
         }
 
         public override void OrderBy_any()
@@ -529,9 +529,9 @@ WHERE (c[""Discriminator""] = ""Product"")");
             base.OrderBy_any();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip(bool isAsync)
@@ -539,9 +539,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip_no_orderby(bool isAsync)
@@ -549,9 +549,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip_no_orderby(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip_Take(bool isAsync)
@@ -559,9 +559,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip_Take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Join_Customers_Orders_Skip_Take(bool isAsync)
@@ -569,9 +569,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Join_Customers_Orders_Skip_Take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Join_Customers_Orders_Skip_Take_followed_by_constant_projection(bool isAsync)
@@ -579,9 +579,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Join_Customers_Orders_Skip_Take_followed_by_constant_projection(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Join_Customers_Orders_Projection_With_String_Concat_Skip_Take(bool isAsync)
@@ -589,9 +589,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Join_Customers_Orders_Orders_Skip_Take_Same_Properties(bool isAsync)
@@ -599,9 +599,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Take_Skip(bool isAsync)
@@ -609,9 +609,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Take_Skip(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_Skip_Distinct(bool isAsync)
@@ -619,9 +619,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_Skip_Distinct(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_Skip_Distinct_Caching(bool isAsync)
@@ -629,9 +629,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_Skip_Distinct_Caching(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_Distinct_Count(bool isAsync)
@@ -639,9 +639,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_Distinct_Count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Take_Where_Distinct_Count(bool isAsync)
@@ -649,9 +649,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Take_Where_Distinct_Count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""FRANK""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.CustomerID = ""FRANK""))");
         }
 
         public override async Task Null_conditional_simple(bool isAsync)
@@ -659,9 +659,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""FRANK""))")
             await base.Null_conditional_simple(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Null_conditional_deep(bool isAsync)
@@ -669,9 +669,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Null_conditional_deep(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Queryable_simple(bool isAsync)
@@ -679,9 +679,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Queryable_simple(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Queryable_simple_anonymous(bool isAsync)
@@ -689,9 +689,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Queryable_simple_anonymous(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Queryable_nested_simple(bool isAsync)
@@ -699,9 +699,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Queryable_nested_simple(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Queryable_simple_anonymous_projection_subquery(bool isAsync)
@@ -709,9 +709,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Queryable_simple_anonymous_projection_subquery(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Queryable_simple_anonymous_subquery(bool isAsync)
@@ -719,9 +719,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Queryable_simple_anonymous_subquery(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_simple(bool isAsync)
@@ -729,9 +729,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_simple(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_simple_parameterized(bool isAsync)
@@ -739,9 +739,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_simple_parameterized(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_simple_projection(bool isAsync)
@@ -749,9 +749,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_simple_projection(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_subquery_projection(bool isAsync)
@@ -759,9 +759,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_subquery_projection(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_Take_Count(bool isAsync)
@@ -769,9 +769,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_Take_Count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Take_OrderBy_Count(bool isAsync)
@@ -779,9 +779,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Take_OrderBy_Count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Any_simple(bool isAsync)
@@ -789,9 +789,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Any_simple(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Any_predicate(bool isAsync)
@@ -799,9 +799,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Any_predicate(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Any_nested_negated(bool isAsync)
@@ -809,9 +809,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Any_nested_negated(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Any_nested_negated2(bool isAsync)
@@ -819,9 +819,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Any_nested_negated2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Any_nested_negated3(bool isAsync)
@@ -829,9 +829,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Any_nested_negated3(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Any_nested(bool isAsync)
@@ -839,9 +839,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Any_nested(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Any_nested2(bool isAsync)
@@ -849,9 +849,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Any_nested2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Any_nested3(bool isAsync)
@@ -859,9 +859,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Any_nested3(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Any_with_multiple_conditions_still_uses_exists()
@@ -869,9 +869,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Any_with_multiple_conditions_still_uses_exists();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task All_top_level(bool isAsync)
@@ -879,9 +879,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.All_top_level(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task All_top_level_column(bool isAsync)
@@ -889,9 +889,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.All_top_level_column(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task All_top_level_subquery(bool isAsync)
@@ -903,9 +903,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                     cs.AllAsync(c1 => c1.CustomerID == "ALFKI" && cs.Any(c2 => cs.Any(c3 => c1.CustomerID == c3.CustomerID))));
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task All_top_level_subquery_ef_property(bool isAsync)
@@ -918,9 +918,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                     c1 => c1.CustomerID == "ALFKI" && cs.Any(c2 => cs.Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task First_client_predicate(bool isAsync)
@@ -928,9 +928,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.First_client_predicate(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_select_many_or(bool isAsync)
@@ -938,9 +938,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_select_many_or(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_select_many_or2(bool isAsync)
@@ -948,9 +948,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_select_many_or2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_select_many_or3(bool isAsync)
@@ -958,9 +958,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_select_many_or3(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_select_many_or4(bool isAsync)
@@ -968,9 +968,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_select_many_or4(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_select_many_or_with_parameter(bool isAsync)
@@ -978,9 +978,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_select_many_or_with_parameter(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task SelectMany_mixed(bool isAsync)
@@ -988,9 +988,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.SelectMany_mixed(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task SelectMany_simple_subquery(bool isAsync)
@@ -998,9 +998,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.SelectMany_simple_subquery(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task SelectMany_simple1(bool isAsync)
@@ -1008,9 +1008,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.SelectMany_simple1(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task SelectMany_simple2(bool isAsync)
@@ -1031,9 +1031,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
                 entryCount: 10);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""City""] = ""London""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Employee"") AND (c.City = ""London""))");
         }
 
         public override async Task SelectMany_entity_deep(bool isAsync)
@@ -1056,9 +1056,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""City""] = ""London""))");
                 entryCount: 9);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 1))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Employee"") AND (c.EmployeeID = 1))");
         }
 
         public override async Task SelectMany_projection1(bool isAsync)
@@ -1066,9 +1066,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 1))");
             await base.SelectMany_projection1(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task SelectMany_projection2(bool isAsync)
@@ -1076,9 +1076,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.SelectMany_projection2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task SelectMany_customer_orders(bool isAsync)
@@ -1097,9 +1097,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
                 e => e.OrderID);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.City = ""London""))");
         }
 
         public override async Task SelectMany_Count(bool isAsync)
@@ -1112,9 +1112,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
                     select c.CustomerID);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.City = ""London""))");
         }
 
         public override async Task SelectMany_LongCount(bool isAsync)
@@ -1127,9 +1127,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
                     select c.CustomerID);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.City = ""London""))");
         }
 
         public override async Task SelectMany_OrderBy_ThenBy_Any(bool isAsync)
@@ -1137,9 +1137,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
             await base.SelectMany_OrderBy_ThenBy_Any(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Join_Where_Count(bool isAsync)
@@ -1147,9 +1147,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Join_Where_Count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_Join_Any(bool isAsync)
@@ -1157,9 +1157,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_Join_Any(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_Join_Exists(bool isAsync)
@@ -1167,9 +1167,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_Join_Exists(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_Join_Exists_Inequality(bool isAsync)
@@ -1177,9 +1177,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_Join_Exists_Inequality(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_Join_Exists_Constant(bool isAsync)
@@ -1187,9 +1187,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_Join_Exists_Constant(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_Join_Not_Exists(bool isAsync)
@@ -1197,9 +1197,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_Join_Not_Exists(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Join_OrderBy_Count(bool isAsync)
@@ -1207,9 +1207,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Join_OrderBy_Count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Multiple_joins_Where_Order_Any(bool isAsync)
@@ -1217,9 +1217,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Multiple_joins_Where_Order_Any(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_join_select(bool isAsync)
@@ -1227,9 +1227,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_join_select(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Where_orderby_join_select(bool isAsync)
@@ -1237,9 +1237,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Where_orderby_join_select(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID != ""ALFKI""))");
         }
 
         public override async Task Where_join_orderby_join_select(bool isAsync)
@@ -1247,9 +1247,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != ""ALFKI""
             await base.Where_join_orderby_join_select(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID != ""ALFKI""))");
         }
 
         public override async Task Where_select_many(bool isAsync)
@@ -1257,9 +1257,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != ""ALFKI""
             await base.Where_select_many(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Where_orderby_select_many(bool isAsync)
@@ -1267,9 +1267,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Where_orderby_select_many(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task SelectMany_cartesian_product_with_ordering(bool isAsync)
@@ -1277,9 +1277,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.SelectMany_cartesian_product_with_ordering(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task SelectMany_Joined_DefaultIfEmpty(bool isAsync)
@@ -1298,9 +1298,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 entryCount: 6);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task SelectMany_Joined_DefaultIfEmpty2(bool isAsync)
@@ -1315,9 +1315,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
                 entryCount: 6);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task SelectMany_Joined(bool isAsync)
@@ -1335,9 +1335,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
                 e => e.ContactName + " " + e.OrderDate);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task SelectMany_Joined_Take(bool isAsync)
@@ -1356,9 +1356,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
                 entryCount: 6);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Take_with_single(bool isAsync)
@@ -1366,9 +1366,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Take_with_single(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_with_single_select_many(bool isAsync)
@@ -1389,9 +1389,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 entryCount: 2);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Distinct_Skip(bool isAsync)
@@ -1399,9 +1399,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Distinct_Skip(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Distinct_Skip_Take(bool isAsync)
@@ -1409,9 +1409,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Distinct_Skip_Take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip_Distinct(bool isAsync)
@@ -1419,9 +1419,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip_Distinct(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip_Take_Distinct(bool isAsync)
@@ -1429,9 +1429,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip_Take_Distinct(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip_Take_Any(bool isAsync)
@@ -1439,9 +1439,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip_Take_Any(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip_Take_All(bool isAsync)
@@ -1449,9 +1449,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip_Take_All(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_All(bool isAsync)
@@ -1459,9 +1459,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_All(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Skip_Take_Any_with_predicate(bool isAsync)
@@ -1469,9 +1469,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Skip_Take_Any_with_predicate(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_Any_with_predicate(bool isAsync)
@@ -1479,9 +1479,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_Any_with_predicate(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy(bool isAsync)
@@ -1489,9 +1489,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_true(bool isAsync)
@@ -1499,9 +1499,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_true(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_integer(bool isAsync)
@@ -1509,9 +1509,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_integer(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_parameter(bool isAsync)
@@ -1519,9 +1519,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_parameter(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_anon(bool isAsync)
@@ -1529,9 +1529,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_anon(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_anon2(bool isAsync)
@@ -1539,9 +1539,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_anon2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_client_mixed(bool isAsync)
@@ -1549,9 +1549,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_client_mixed(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_multiple_queries(bool isAsync)
@@ -1559,9 +1559,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_multiple_queries(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Take_Distinct(bool isAsync)
@@ -1569,9 +1569,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Take_Distinct(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Distinct_Take(bool isAsync)
@@ -1579,9 +1579,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Distinct_Take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Distinct_Take_Count(bool isAsync)
@@ -1589,9 +1589,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Distinct_Take_Count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task OrderBy_shadow(bool isAsync)
@@ -1599,9 +1599,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.OrderBy_shadow(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task OrderBy_multiple(bool isAsync)
@@ -1609,9 +1609,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.OrderBy_multiple(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_ThenBy_Any(bool isAsync)
@@ -1619,9 +1619,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_ThenBy_Any(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_correlated_subquery1(bool isAsync)
@@ -1629,9 +1629,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_correlated_subquery1(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_correlated_subquery2(bool isAsync)
@@ -1639,9 +1639,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_correlated_subquery2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Where_subquery_recursive_trivial(bool isAsync)
@@ -1649,9 +1649,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Where_subquery_recursive_trivial(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Where_query_composition4(bool isAsync)
@@ -1659,9 +1659,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Where_query_composition4(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_subquery_expression(bool isAsync)
@@ -1677,9 +1677,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 entryCount: 52);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Where_subquery_expression_same_parametername(bool isAsync)
@@ -1695,9 +1695,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
                 entryCount: 1);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Select_DTO_distinct_translated_to_server()
@@ -1705,9 +1705,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Select_DTO_distinct_translated_to_server();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderID < 10300))");
         }
 
         public override void Select_DTO_constructor_distinct_translated_to_server()
@@ -1715,9 +1715,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
             base.Select_DTO_constructor_distinct_translated_to_server();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderID < 10300))");
         }
 
         public override void Select_DTO_with_member_init_distinct_translated_to_server()
@@ -1725,9 +1725,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
             base.Select_DTO_with_member_init_distinct_translated_to_server();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderID < 10300))");
         }
 
         public override void Select_nested_collection_count_using_DTO()
@@ -1735,9 +1735,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
             base.Select_nested_collection_count_using_DTO();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(bool isAsync)
@@ -1745,9 +1745,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderID < 10300))");
         }
 
         public override void Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server()
@@ -1755,9 +1755,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
             base.Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_correlated_subquery_projection(bool isAsync)
@@ -1765,9 +1765,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_correlated_subquery_projection(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_correlated_subquery_filtered(bool isAsync)
@@ -1775,9 +1775,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_correlated_subquery_filtered(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_correlated_subquery_ordered(bool isAsync)
@@ -1785,9 +1785,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_correlated_subquery_ordered(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Where_subquery_on_bool(bool isAsync)
@@ -1795,9 +1795,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_subquery_on_bool(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Product"")");
         }
 
         public override async Task Where_subquery_on_collection(bool isAsync)
@@ -1813,9 +1813,9 @@ WHERE (c[""Discriminator""] = ""Product"")");
                 entryCount: 1);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] = 72))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Product"") AND (c.ProductID = 72))");
         }
 
         public override async Task Select_many_cross_join_same_collection(bool isAsync)
@@ -1823,9 +1823,9 @@ WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] = 72))");
             await base.Select_many_cross_join_same_collection(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_null_coalesce_operator(bool isAsync)
@@ -1833,9 +1833,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_null_coalesce_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_null_coalesce_operator(bool isAsync)
@@ -1843,9 +1843,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_null_coalesce_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_conditional_operator(bool isAsync)
@@ -1853,9 +1853,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_conditional_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_conditional_operator_where_condition_false(bool isAsync)
@@ -1863,9 +1863,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_conditional_operator_where_condition_false(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_comparison_operator(bool isAsync)
@@ -1873,9 +1873,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_comparison_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Projection_null_coalesce_operator(bool isAsync)
@@ -1883,9 +1883,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Projection_null_coalesce_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Filter_coalesce_operator(bool isAsync)
@@ -1893,9 +1893,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Filter_coalesce_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CompanyName""] ?? c[""ContactName""]) = ""The Big Cheese""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND ((c.CompanyName ?? c.ContactName) = ""The Big Cheese""))");
         }
 
         public override async Task Take_skip_null_coalesce_operator(bool isAsync)
@@ -1903,9 +1903,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CompanyName""] ?? c[""Con
             await base.Take_skip_null_coalesce_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_take_null_coalesce_operator(bool isAsync)
@@ -1913,9 +1913,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_take_null_coalesce_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_take_skip_null_coalesce_operator(bool isAsync)
@@ -1923,9 +1923,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_take_skip_null_coalesce_operator(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_take_skip_null_coalesce_operator2(bool isAsync)
@@ -1933,9 +1933,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_take_skip_null_coalesce_operator2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_take_skip_null_coalesce_operator3(bool isAsync)
@@ -1943,9 +1943,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_take_skip_null_coalesce_operator3(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Selected_column_can_coalesce()
@@ -1953,9 +1953,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Selected_column_can_coalesce();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DateTime_parse_is_inlined(bool isAsync)
@@ -1963,9 +1963,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.DateTime_parse_is_inlined(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > ""1998-01-01T12:00:00""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate > ""1998-01-01T12:00:00""))");
         }
 
         public override async Task DateTime_parse_is_parameterized_when_from_closure(bool isAsync)
@@ -1976,8 +1976,8 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > ""1998-01-01T1
                 @"@__Parse_0='1998-01-01T12:00:00'
 
 SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__Parse_0))");
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate > @__Parse_0))");
         }
 
         public override async Task New_DateTime_is_inlined(bool isAsync)
@@ -1985,9 +1985,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__Parse_0))")
             await base.New_DateTime_is_inlined(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > ""1998-01-01T12:00:00""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate > ""1998-01-01T12:00:00""))");
         }
 
         public override async Task New_DateTime_is_parameterized_when_from_closure(bool isAsync)
@@ -1998,14 +1998,14 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > ""1998-01-01T1
                 @"@__p_0='1998-01-01T12:00:00'
 
 SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__p_0))",
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate > @__p_0))",
                 //
                 @"@__p_0='1998-01-01T11:00:00'
 
 SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__p_0))");
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate > @__p_0))");
         }
 
         public override void Random_next_is_not_funcletized_1()
@@ -2013,9 +2013,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__p_0))");
             base.Random_next_is_not_funcletized_1();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Random_next_is_not_funcletized_2()
@@ -2023,9 +2023,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Random_next_is_not_funcletized_2();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Random_next_is_not_funcletized_3()
@@ -2033,9 +2033,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Random_next_is_not_funcletized_3();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Random_next_is_not_funcletized_4()
@@ -2043,9 +2043,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Random_next_is_not_funcletized_4();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Random_next_is_not_funcletized_5()
@@ -2053,9 +2053,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Random_next_is_not_funcletized_5();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Random_next_is_not_funcletized_6()
@@ -2063,9 +2063,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Random_next_is_not_funcletized_6();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Environment_newline_is_funcletized(bool isAsync)
@@ -2073,9 +2073,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Environment_newline_is_funcletized(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task String_concat_with_navigation1(bool isAsync)
@@ -2083,9 +2083,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.String_concat_with_navigation1(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task String_concat_with_navigation2(bool isAsync)
@@ -2093,9 +2093,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.String_concat_with_navigation2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override void Select_bitwise_or()
@@ -2103,9 +2103,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             base.Select_bitwise_or();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Select_bitwise_or_multiple()
@@ -2113,9 +2113,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Select_bitwise_or_multiple();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Select_bitwise_and()
@@ -2123,9 +2123,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Select_bitwise_and();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Select_bitwise_and_or()
@@ -2133,9 +2133,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Select_bitwise_and_or();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override Task Where_bitwise_or_with_logical_or(bool isAsync)
@@ -2151,9 +2151,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Where_bitwise_and_with_logical_and(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")) AND (c[""CustomerID""] = ""ANTON"")))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (((c.CustomerID = ""ALFKI"") & (c.CustomerID = ""ANATR"")) AND (c.CustomerID = ""ANTON"")))");
         }
 
         public override Task Where_bitwise_or_with_logical_and(bool isAsync)
@@ -2169,9 +2169,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"
             await base.Where_bitwise_and_with_logical_or(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")) OR (c[""CustomerID""] = ""ANTON"")))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (((c.CustomerID = ""ALFKI"") & (c.CustomerID = ""ANATR"")) OR (c.CustomerID = ""ANTON"")))");
         }
 
         public override void Select_bitwise_or_with_logical_or()
@@ -2179,9 +2179,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"
             base.Select_bitwise_or_with_logical_or();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Select_bitwise_and_with_logical_and()
@@ -2189,9 +2189,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Select_bitwise_and_with_logical_and();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Handle_materialization_properly_when_more_than_two_query_sources_are_involved(bool isAsync)
@@ -2199,9 +2199,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Handle_materialization_properly_when_more_than_two_query_sources_are_involved(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override Task Parameter_extraction_short_circuits_1(bool isAsync)
@@ -2217,9 +2217,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Parameter_extraction_short_circuits_2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override Task Parameter_extraction_short_circuits_3(bool isAsync)
@@ -2235,9 +2235,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Subquery_member_pushdown_does_not_change_original_subquery_model(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Query_expression_with_to_string_and_contains(bool isAsync)
@@ -2245,9 +2245,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Query_expression_with_to_string_and_contains(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_expression_long_to_string(bool isAsync)
@@ -2255,9 +2255,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_expression_long_to_string(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_int_to_string(bool isAsync)
@@ -2265,9 +2265,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_int_to_string(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool isAsync)
@@ -2275,9 +2275,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.ToString_with_formatter_is_evaluated_on_the_client(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_other_to_string(bool isAsync)
@@ -2285,9 +2285,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_other_to_string(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_date_add_year(bool isAsync)
@@ -2295,9 +2295,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_date_add_year(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_datetime_add_month(bool isAsync)
@@ -2305,9 +2305,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_datetime_add_month(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_datetime_add_hour(bool isAsync)
@@ -2315,9 +2315,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_datetime_add_hour(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_datetime_add_minute(bool isAsync)
@@ -2325,9 +2325,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_datetime_add_minute(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_datetime_add_second(bool isAsync)
@@ -2335,9 +2335,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_datetime_add_second(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_date_add_milliseconds_above_the_range(bool isAsync)
@@ -2345,9 +2345,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_date_add_milliseconds_above_the_range(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_date_add_milliseconds_below_the_range(bool isAsync)
@@ -2355,9 +2355,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_date_add_milliseconds_below_the_range(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool isAsync)
@@ -2365,9 +2365,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_date_add_milliseconds_large_number_divided(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override async Task Select_expression_references_are_updated_correctly_with_subquery(bool isAsync)
@@ -2375,9 +2375,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             await base.Select_expression_references_are_updated_correctly_with_subquery(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderDate != null))");
         }
 
         public override void DefaultIfEmpty_without_group_join()
@@ -2385,9 +2385,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
             base.DefaultIfEmpty_without_group_join();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.City = ""London""))");
         }
 
         public override async Task DefaultIfEmpty_in_subquery(bool isAsync)
@@ -2406,9 +2406,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
                 e => e.CustomerID + " " + e.OrderID);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.City = ""London""))");
         }
 
         public override async Task DefaultIfEmpty_in_subquery_nested(bool isAsync)
@@ -2430,9 +2430,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
                 e => e.CustomerID + " " + e.OrderID);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""Seattle""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.City = ""Seattle""))");
         }
 
         public override async Task OrderBy_skip_take(bool isAsync)
@@ -2440,9 +2440,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""Seattle""))");
             await base.OrderBy_skip_take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_skip_skip_take(bool isAsync)
@@ -2450,9 +2450,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_skip_skip_take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_skip_take_take(bool isAsync)
@@ -2460,9 +2460,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_skip_take_take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_skip_take_take_take_take(bool isAsync)
@@ -2470,9 +2470,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_skip_take_take_take_take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_skip_take_skip_take_skip(bool isAsync)
@@ -2480,9 +2480,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_skip_take_skip_take_skip(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_skip_take_distinct(bool isAsync)
@@ -2490,9 +2490,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_skip_take_distinct(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_coalesce_take_distinct(bool isAsync)
@@ -2500,9 +2500,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_coalesce_take_distinct(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Product"")");
         }
 
         public override async Task OrderBy_coalesce_skip_take_distinct(bool isAsync)
@@ -2510,9 +2510,9 @@ WHERE (c[""Discriminator""] = ""Product"")");
             await base.OrderBy_coalesce_skip_take_distinct(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Product"")");
         }
 
         public override async Task OrderBy_coalesce_skip_take_distinct_take(bool isAsync)
@@ -2520,9 +2520,9 @@ WHERE (c[""Discriminator""] = ""Product"")");
             await base.OrderBy_coalesce_skip_take_distinct_take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Product"")");
         }
 
         public override async Task OrderBy_skip_take_distinct_orderby_take(bool isAsync)
@@ -2530,9 +2530,9 @@ WHERE (c[""Discriminator""] = ""Product"")");
             await base.OrderBy_skip_take_distinct_orderby_take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task No_orderby_added_for_fully_translated_manually_constructed_LOJ(bool isAsync)
@@ -2540,9 +2540,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.No_orderby_added_for_fully_translated_manually_constructed_LOJ(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(bool isAsync)
@@ -2550,9 +2550,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(
@@ -2561,9 +2561,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(
@@ -2572,9 +2572,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(bool isAsync)
@@ -2582,9 +2582,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Employee"")");
         }
 
         public override async Task Contains_with_DateTime_Date(bool isAsync)
@@ -2592,9 +2592,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
             await base.Contains_with_DateTime_Date(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Contains_with_subquery_involving_join_binds_to_correct_table(bool isAsync)
@@ -2610,9 +2610,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
                 entryCount: 1);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Complex_query_with_repeated_query_model_compiles_correctly(bool isAsync)
@@ -2620,9 +2620,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Complex_query_with_repeated_query_model_compiles_correctly(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Complex_query_with_repeated_nested_query_model_compiles_correctly(bool isAsync)
@@ -2630,9 +2630,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Complex_query_with_repeated_nested_query_model_compiles_correctly(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Anonymous_member_distinct_where(bool isAsync)
@@ -2640,9 +2640,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Anonymous_member_distinct_where(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Anonymous_member_distinct_orderby(bool isAsync)
@@ -2650,9 +2650,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Anonymous_member_distinct_orderby(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Anonymous_member_distinct_result(bool isAsync)
@@ -2660,9 +2660,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Anonymous_member_distinct_result(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Anonymous_complex_distinct_where(bool isAsync)
@@ -2670,9 +2670,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Anonymous_complex_distinct_where(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Anonymous_complex_distinct_orderby(bool isAsync)
@@ -2680,9 +2680,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Anonymous_complex_distinct_orderby(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Anonymous_complex_distinct_result(bool isAsync)
@@ -2690,9 +2690,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Anonymous_complex_distinct_result(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Anonymous_complex_orderby(bool isAsync)
@@ -2700,9 +2700,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Anonymous_complex_orderby(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Anonymous_subquery_orderby(bool isAsync)
@@ -2717,9 +2717,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 assertOrder: true);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.City = ""London""))");
         }
 
         public override async Task DTO_member_distinct_where(bool isAsync)
@@ -2727,9 +2727,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
             await base.DTO_member_distinct_where(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DTO_member_distinct_orderby(bool isAsync)
@@ -2737,9 +2737,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.DTO_member_distinct_orderby(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DTO_member_distinct_result(bool isAsync)
@@ -2747,9 +2747,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.DTO_member_distinct_result(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DTO_complex_distinct_where(bool isAsync)
@@ -2757,9 +2757,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.DTO_complex_distinct_where(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DTO_complex_distinct_orderby(bool isAsync)
@@ -2767,9 +2767,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.DTO_complex_distinct_orderby(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DTO_complex_distinct_result(bool isAsync)
@@ -2777,9 +2777,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.DTO_complex_distinct_result(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DTO_complex_orderby(bool isAsync)
@@ -2787,9 +2787,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.DTO_complex_orderby(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task DTO_subquery_orderby(bool isAsync)
@@ -2805,9 +2805,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 elementAsserter: (e, a) => Assert.Equal(e.Property, a.Property));
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Include_with_orderby_skip_preserves_ordering(bool isAsync)
@@ -2815,9 +2815,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Include_with_orderby_skip_preserves_ordering(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != ""VAFFE"") AND (c[""CustomerID""] != ""DRACD"")))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND ((c.CustomerID != ""VAFFE"") AND (c.CustomerID != ""DRACD"")))");
         }
 
         public override async Task Int16_parameter_can_be_used_for_int_column(bool isAsync)
@@ -2825,9 +2825,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != ""VAFFE"
             await base.Int16_parameter_can_be_used_for_int_column(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10300))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderID = 10300))");
         }
 
         public override async Task Subquery_is_null_translated_correctly(bool isAsync)
@@ -2844,9 +2844,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10300))");
                 entryCount: 0);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Subquery_is_not_null_translated_correctly(bool isAsync)
@@ -2863,9 +2863,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
                 entryCount: 1);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Select_take_average(bool isAsync)
@@ -2873,9 +2873,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Select_take_average(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_take_count(bool isAsync)
@@ -2883,9 +2883,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_take_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_orderBy_take_count(bool isAsync)
@@ -2893,9 +2893,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_orderBy_take_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_take_long_count(bool isAsync)
@@ -2903,9 +2903,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_take_long_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_orderBy_take_long_count(bool isAsync)
@@ -2913,9 +2913,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_orderBy_take_long_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_take_max(bool isAsync)
@@ -2923,9 +2923,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_take_max(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_take_min(bool isAsync)
@@ -2933,9 +2933,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_take_min(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_take_sum(bool isAsync)
@@ -2943,9 +2943,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_take_sum(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_skip_average(bool isAsync)
@@ -2953,9 +2953,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_skip_average(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_skip_count(bool isAsync)
@@ -2963,9 +2963,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_skip_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_orderBy_skip_count(bool isAsync)
@@ -2973,9 +2973,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_orderBy_skip_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_skip_long_count(bool isAsync)
@@ -2983,9 +2983,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_skip_long_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_orderBy_skip_long_count(bool isAsync)
@@ -2993,9 +2993,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_orderBy_skip_long_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_skip_max(bool isAsync)
@@ -3003,9 +3003,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_skip_max(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_skip_min(bool isAsync)
@@ -3013,9 +3013,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_skip_min(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_skip_sum(bool isAsync)
@@ -3023,9 +3023,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_skip_sum(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_distinct_average(bool isAsync)
@@ -3033,9 +3033,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_distinct_average(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_distinct_count(bool isAsync)
@@ -3043,9 +3043,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_distinct_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_distinct_long_count(bool isAsync)
@@ -3053,9 +3053,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_distinct_long_count(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Select_distinct_max(bool isAsync)
@@ -3063,9 +3063,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Select_distinct_max(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_distinct_min(bool isAsync)
@@ -3073,9 +3073,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_distinct_min(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Select_distinct_sum(bool isAsync)
@@ -3083,9 +3083,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Select_distinct_sum(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Comparing_to_fixed_string_parameter(bool isAsync)
@@ -3093,9 +3093,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.Comparing_to_fixed_string_parameter(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Comparing_entities_using_Equals(bool isAsync)
@@ -3103,9 +3103,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Comparing_entities_using_Equals(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Comparing_different_entity_types_using_Equals(bool isAsync)
@@ -3120,9 +3120,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                             select c.CustomerID);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Comparing_entity_to_null_using_Equals(bool isAsync)
@@ -3130,9 +3130,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Comparing_entity_to_null_using_Equals(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Comparing_navigations_using_Equals(bool isAsync)
@@ -3153,9 +3153,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 e => e.Id1 + " " + e.Id2);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Comparing_navigations_using_static_Equals(bool isAsync)
@@ -3176,9 +3176,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
                 e => e.Id1 + " " + e.Id2);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Comparing_non_matching_entities_using_Equals(bool isAsync)
@@ -3198,9 +3198,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
                 e => e.Id1 + " " + e.Id2);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Comparing_non_matching_collection_navigations_using_Equals(bool isAsync)
@@ -3220,9 +3220,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
                 e => e.Id1 + " " + e.Id2);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Comparing_collection_navigation_to_null(bool isAsync)
@@ -3230,9 +3230,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Comparing_collection_navigation_to_null(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = null))");
         }
 
         public override async Task Comparing_collection_navigation_to_null_complex(bool isAsync)
@@ -3240,9 +3240,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
             await base.Comparing_collection_navigation_to_null_complex(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""OrderDetail"")");
         }
 
         public override async Task Compare_collection_navigation_with_itself(bool isAsync)
@@ -3250,9 +3250,9 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             await base.Compare_collection_navigation_with_itself(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Compare_two_collection_navigations_with_different_query_sources(bool isAsync)
@@ -3260,9 +3260,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Compare_two_collection_navigations_with_different_query_sources(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Compare_two_collection_navigations_using_equals(bool isAsync)
@@ -3270,9 +3270,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Compare_two_collection_navigations_using_equals(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Compare_two_collection_navigations_with_different_property_chains(bool isAsync)
@@ -3280,9 +3280,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Compare_two_collection_navigations_with_different_property_chains(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task OrderBy_ThenBy_same_column_different_direction(bool isAsync)
@@ -3290,9 +3290,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.OrderBy_ThenBy_same_column_different_direction(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_OrderBy_same_column_different_direction(bool isAsync)
@@ -3300,9 +3300,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_OrderBy_same_column_different_direction(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(bool isAsync)
@@ -3310,9 +3310,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result(bool isAsync)
@@ -3329,21 +3329,21 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
                             }));
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))",
                 //
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderID < 10250))",
                 //
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")",
                 //
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task OrderBy_Dto_projection_skip_take(bool isAsync)
@@ -3351,9 +3351,9 @@ WHERE (c[""Discriminator""] = ""Order"")");
             await base.OrderBy_Dto_projection_skip_take(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Streaming_chained_sync_query()
@@ -3384,9 +3384,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             }
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Customer"") AND (c.CustomerID = ""ALFKI""))");
         }
 
         public override async Task Join_take_count_works(bool isAsync)
@@ -3394,9 +3394,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Join_take_count_works(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] > 690) AND (c[""OrderID""] < 710)))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND ((c.OrderID > 690) AND (c.OrderID < 710)))");
         }
 
         public override async Task OrderBy_empty_list_contains(bool isAsync)
@@ -3404,9 +3404,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] > 690) AND (c[""O
             await base.OrderBy_empty_list_contains(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task OrderBy_empty_list_does_not_contains(bool isAsync)
@@ -3414,9 +3414,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.OrderBy_empty_list_does_not_contains(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Manual_expression_tree_typed_null_equality()
@@ -3424,9 +3424,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             base.Manual_expression_tree_typed_null_equality();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Order"")");
         }
 
         public override async Task Let_subquery_with_multiple_occurences(bool isAsync)
@@ -3445,25 +3445,25 @@ WHERE (c[""Discriminator""] = ""Order"")");
                       });
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""Order"") AND (c.OrderID < 10250))",
                 //
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""OrderDetail"") AND (c.Quantity < 10))",
                 //
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""OrderDetail"") AND (c.Quantity < 10))",
                 //
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))",
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""OrderDetail"") AND (c.Quantity < 10))",
                 //
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE ((c.Type = ""OrderDetail"") AND (c.Quantity < 10))");
         }
 
         public override async Task Let_entity_equality_to_null(bool isAsync)
@@ -3471,9 +3471,9 @@ WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))");
             await base.Let_entity_equality_to_null(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Let_entity_equality_to_other_entity(bool isAsync)
@@ -3481,9 +3481,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Let_entity_equality_to_other_entity(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task SelectMany_after_client_method(bool isAsync)
@@ -3491,9 +3491,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.SelectMany_after_client_method(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Collection_navigation_equal_to_null_for_subquery(bool isAsync)
@@ -3505,9 +3505,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 entryCount: 89);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool isAsync)
@@ -3520,9 +3520,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 entryCount: 89);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override async Task Collection_navigation_equality_rewrite_for_subquery(bool isAsync)
@@ -3530,9 +3530,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             await base.Collection_navigation_equality_rewrite_for_subquery(isAsync);
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"SELECT OBJECT_ADD(c, 'id', META(c).id) AS c
+FROM eftest c
+WHERE (c.Type = ""Customer"")");
         }
 
         public override void Throws_on_concurrent_query_first()


### PR DESCRIPTION
Motivation
----------
Be able to execute basic N1QL queries.

Modifications
-------------
Implemented ExecuteSqlQuery* and Document*Enumerable for both sync and
async query execution.

Adjusted QueryShaperExpression to extract the returned object from the
results by its name, "c".

Updated one file's worth of tests to handle the N1QL syntax we are now
generating instead of the previous CosmosDB syntax.

Results
-------
Simple queries now execute and their tests can pass with a tweak. Due
to #17, you must comment out the _cluster.Dispose() in
CouchbaseClientWrapper for the tests to work.

Note that asynchronous querying will execute the query itself async, but
doesn't stream the results asynchronously. This is pending support in
the Couchbase SDK 3.x for asynchronous stream results.

fixes #6
fixes #7


**Please check if the PR fulfills these requirements**

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.